### PR TITLE
added connection string as env var

### DIFF
--- a/azure/linux-functionapp/locals.tf
+++ b/azure/linux-functionapp/locals.tf
@@ -1,6 +1,6 @@
 locals {
   default_app_settings = {
-
+    "AzureWebJobsStorage" = azurerm_storage_account.app.primary_connection_string
   }
   app_settings = merge(local.default_app_settings, var.app_settings)
 


### PR DESCRIPTION
# Description

@BethFleming encountered a bug whereby the connection string for the storage account was not passed into the Application Settings.

## Type of change

  - [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my code
  - [X] I have commented my code, particularly in hard-to-understand areas
  - [X] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings e.g. code analysis tooling or general use of the changed code
