### PR TITLE
Add backend address pool associations to VM modules

### DIFF
--- a/azure/linux-virtual-machine/README.md
+++ b/azure/linux-virtual-machine/README.md
@@ -35,7 +35,7 @@ When using a marketplace image, ensure that you accept the terms using the cli t
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group this module will use. | `string` | n/a | yes |
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | Subnet ID of the virtual machine. | `string` | n/a | yes |
 | <a name="input_accept_terms"></a> [accept\_terms](#input\_accept\_terms) | Enable if terms are needed to be accepted | `bool` | `false` | no |
-| <a name="input_agw_backend_address_pool_ids"></a> [agw\_backend\_address\_pool\_ids](#input\_agw\_backend\_address\_pool\_ids) | IDs of application gateways backends to assign this virtual machine's primary NIC to. | `set(string)` | `[]` | no |
+| <a name="input_agw_backend_address_pool_ids"></a> [agw\_backend\_address\_pool\_ids](#input\_agw\_backend\_address\_pool\_ids) | IDs of application gateways backends to assign this virtual machine's primary NIC to. | `list(string)` | `[]` | no |
 | <a name="input_autoshutdown"></a> [autoshutdown](#input\_autoshutdown) | Describes the autoshutdown configuration with time being in 24h format and timezone being a supported timezone. | <pre>object({<br>    time     = optional(string, "2200")<br>    timezone = optional(string, "UTC")<br>    email    = optional(string)<br>  })</pre> | `null` | no |
 | <a name="input_availability_set_id"></a> [availability\_set\_id](#input\_availability\_set\_id) | Availability set ID to add this virtual machine to. | `string` | `null` | no |
 | <a name="input_computer_name"></a> [computer\_name](#input\_computer\_name) | The OS-level computer name of the virtual machine. | `string` | `null` | no |
@@ -49,7 +49,7 @@ When using a marketplace image, ensure that you accept the terms using the cli t
 | <a name="input_identity_ids"></a> [identity\_ids](#input\_identity\_ids) | User assigned identity IDs to append to this virtual machine. | `list(string)` | `[]` | no |
 | <a name="input_ip_address"></a> [ip\_address](#input\_ip\_address) | Private IP address of the virtual machine NIC. | `string` | `null` | no |
 | <a name="input_ip_forwarding"></a> [ip\_forwarding](#input\_ip\_forwarding) | Enable IP forwarding on the virtual machine NIC. | `bool` | `false` | no |
-| <a name="input_lb_backend_address_pool_ids"></a> [lb\_backend\_address\_pool\_ids](#input\_lb\_backend\_address\_pool\_ids) | IDs of load balancer backends to assign this virtual machine's primary NIC to. | `set(string)` | `[]` | no |
+| <a name="input_lb_backend_address_pool_ids"></a> [lb\_backend\_address\_pool\_ids](#input\_lb\_backend\_address\_pool\_ids) | IDs of load balancer backends to assign this virtual machine's primary NIC to. | `list(string)` | `[]` | no |
 | <a name="input_license_type"></a> [license\_type](#input\_license\_type) | License type to use when building the virtual machine. | `string` | `null` | no |
 | <a name="input_location"></a> [location](#input\_location) | The location of created resources. | `string` | `"uksouth"` | no |
 | <a name="input_network_security_group_enabled"></a> [network\_security\_group\_enabled](#input\_network\_security\_group\_enabled) | Assign a network security group. | `bool` | `false` | no |

--- a/azure/linux-virtual-machine/README.md
+++ b/azure/linux-virtual-machine/README.md
@@ -35,6 +35,7 @@ When using a marketplace image, ensure that you accept the terms using the cli t
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group this module will use. | `string` | n/a | yes |
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | Subnet ID of the virtual machine. | `string` | n/a | yes |
 | <a name="input_accept_terms"></a> [accept\_terms](#input\_accept\_terms) | Enable if terms are needed to be accepted | `bool` | `false` | no |
+| <a name="input_agw_backend_address_pool_ids"></a> [agw\_backend\_address\_pool\_ids](#input\_agw\_backend\_address\_pool\_ids) | IDs of application gateways backends to assign this virtual machine's primary NIC to. | `set(string)` | `[]` | no |
 | <a name="input_autoshutdown"></a> [autoshutdown](#input\_autoshutdown) | Describes the autoshutdown configuration with time being in 24h format and timezone being a supported timezone. | <pre>object({<br>    time     = optional(string, "2200")<br>    timezone = optional(string, "UTC")<br>    email    = optional(string)<br>  })</pre> | `null` | no |
 | <a name="input_availability_set_id"></a> [availability\_set\_id](#input\_availability\_set\_id) | Availability set ID to add this virtual machine to. | `string` | `null` | no |
 | <a name="input_computer_name"></a> [computer\_name](#input\_computer\_name) | The OS-level computer name of the virtual machine. | `string` | `null` | no |
@@ -48,6 +49,7 @@ When using a marketplace image, ensure that you accept the terms using the cli t
 | <a name="input_identity_ids"></a> [identity\_ids](#input\_identity\_ids) | User assigned identity IDs to append to this virtual machine. | `list(string)` | `[]` | no |
 | <a name="input_ip_address"></a> [ip\_address](#input\_ip\_address) | Private IP address of the virtual machine NIC. | `string` | `null` | no |
 | <a name="input_ip_forwarding"></a> [ip\_forwarding](#input\_ip\_forwarding) | Enable IP forwarding on the virtual machine NIC. | `bool` | `false` | no |
+| <a name="input_lb_backend_address_pool_ids"></a> [lb\_backend\_address\_pool\_ids](#input\_lb\_backend\_address\_pool\_ids) | IDs of load balancer backends to assign this virtual machine's primary NIC to. | `set(string)` | `[]` | no |
 | <a name="input_license_type"></a> [license\_type](#input\_license\_type) | License type to use when building the virtual machine. | `string` | `null` | no |
 | <a name="input_location"></a> [location](#input\_location) | The location of created resources. | `string` | `"uksouth"` | no |
 | <a name="input_network_security_group_enabled"></a> [network\_security\_group\_enabled](#input\_network\_security\_group\_enabled) | Assign a network security group. | `bool` | `false` | no |
@@ -88,6 +90,8 @@ When using a marketplace image, ensure that you accept the terms using the cli t
 | [azurerm_marketplace_agreement.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/marketplace_agreement) | resource |
 | [azurerm_monitor_data_collection_rule_association.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_data_collection_rule_association) | resource |
 | [azurerm_network_interface.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface) | resource |
+| [azurerm_network_interface_application_gateway_backend_address_pool_association.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface_application_gateway_backend_address_pool_association) | resource |
+| [azurerm_network_interface_backend_address_pool_association.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface_backend_address_pool_association) | resource |
 | [azurerm_network_interface_security_group_association.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface_security_group_association) | resource |
 | [azurerm_public_ip.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |
 | [azurerm_virtual_machine_extension.main_aadlogin](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_machine_extension) | resource |

--- a/azure/linux-virtual-machine/main.tf
+++ b/azure/linux-virtual-machine/main.tf
@@ -27,6 +27,22 @@ resource "azurerm_network_interface" "main" {
   }
 }
 
+resource "azurerm_network_interface_backend_address_pool_association" "main" {
+  for_each = var.lb_backend_address_pool_ids
+
+  ip_configuration_name   = one(azurerm_network_interface.main.ip_configuration[*].name)
+  network_interface_id    = azurerm_network_interface.main.id
+  backend_address_pool_id = each.value
+}
+
+resource "azurerm_network_interface_application_gateway_backend_address_pool_association" "main" {
+  for_each = var.agw_backend_address_pool_ids
+
+  ip_configuration_name   = one(azurerm_network_interface.main.ip_configuration[*].name)
+  network_interface_id    = azurerm_network_interface.main.id
+  backend_address_pool_id = each.value
+}
+
 resource "azurerm_network_interface_security_group_association" "main" {
   count = var.network_security_group_enabled ? 1 : 0
 

--- a/azure/linux-virtual-machine/main.tf
+++ b/azure/linux-virtual-machine/main.tf
@@ -28,19 +28,19 @@ resource "azurerm_network_interface" "main" {
 }
 
 resource "azurerm_network_interface_backend_address_pool_association" "main" {
-  for_each = var.lb_backend_address_pool_ids
+  count = length(var.lb_backend_address_pool_ids)
 
   ip_configuration_name   = one(azurerm_network_interface.main.ip_configuration[*].name)
   network_interface_id    = azurerm_network_interface.main.id
-  backend_address_pool_id = each.value
+  backend_address_pool_id = var.lb_backend_address_pool_ids[count.index]
 }
 
 resource "azurerm_network_interface_application_gateway_backend_address_pool_association" "main" {
-  for_each = var.agw_backend_address_pool_ids
+  count = length(var.agw_backend_address_pool_ids)
 
   ip_configuration_name   = one(azurerm_network_interface.main.ip_configuration[*].name)
   network_interface_id    = azurerm_network_interface.main.id
-  backend_address_pool_id = each.value
+  backend_address_pool_id = var.agw_backend_address_pool_ids[count.index]
 }
 
 resource "azurerm_network_interface_security_group_association" "main" {

--- a/azure/linux-virtual-machine/variables.tf
+++ b/azure/linux-virtual-machine/variables.tf
@@ -82,13 +82,13 @@ variable "public_ip_enabled" {
 
 variable "lb_backend_address_pool_ids" {
   description = "IDs of load balancer backends to assign this virtual machine's primary NIC to."
-  type        = set(string)
+  type        = list(string)
   default     = []
 }
 
 variable "agw_backend_address_pool_ids" {
   description = "IDs of application gateways backends to assign this virtual machine's primary NIC to."
-  type        = set(string)
+  type        = list(string)
   default     = []
 }
 

--- a/azure/linux-virtual-machine/variables.tf
+++ b/azure/linux-virtual-machine/variables.tf
@@ -80,6 +80,18 @@ variable "public_ip_enabled" {
   default     = false
 }
 
+variable "lb_backend_address_pool_ids" {
+  description = "IDs of load balancer backends to assign this virtual machine's primary NIC to."
+  type        = set(string)
+  default     = []
+}
+
+variable "agw_backend_address_pool_ids" {
+  description = "IDs of application gateways backends to assign this virtual machine's primary NIC to."
+  type        = set(string)
+  default     = []
+}
+
 variable "network_security_group_enabled" {
   description = "Assign a network security group."
   type        = bool

--- a/azure/windows-virtual-machine/README.md
+++ b/azure/windows-virtual-machine/README.md
@@ -35,7 +35,7 @@ When using a marketplace image, ensure that you accept the terms using the cli t
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group this module will use. | `string` | n/a | yes |
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | Subnet ID of the virtual machine. | `string` | n/a | yes |
 | <a name="input_accept_terms"></a> [accept\_terms](#input\_accept\_terms) | Enable if terms are needed to be accepted | `bool` | `false` | no |
-| <a name="input_agw_backend_address_pool_ids"></a> [agw\_backend\_address\_pool\_ids](#input\_agw\_backend\_address\_pool\_ids) | IDs of application gateways backends to assign this virtual machine's primary NIC to. | `set(string)` | `[]` | no |
+| <a name="input_agw_backend_address_pool_ids"></a> [agw\_backend\_address\_pool\_ids](#input\_agw\_backend\_address\_pool\_ids) | IDs of application gateways backends to assign this virtual machine's primary NIC to. | `list(string)` | `[]` | no |
 | <a name="input_autoshutdown"></a> [autoshutdown](#input\_autoshutdown) | Describes the autoshutdown configuration with time being in 24h format and timezone being a supported timezone. | <pre>object({<br>    time     = optional(string, "2200")<br>    timezone = optional(string, "UTC")<br>    email    = optional(string)<br>  })</pre> | `null` | no |
 | <a name="input_availability_set_id"></a> [availability\_set\_id](#input\_availability\_set\_id) | Availability set ID to add this virtual machine to. | `string` | `null` | no |
 | <a name="input_computer_name"></a> [computer\_name](#input\_computer\_name) | The OS-level computer name of the virtual machine. | `string` | `null` | no |
@@ -49,7 +49,7 @@ When using a marketplace image, ensure that you accept the terms using the cli t
 | <a name="input_identity_ids"></a> [identity\_ids](#input\_identity\_ids) | User assigned identity IDs to append to this virtual machine. | `list(string)` | `[]` | no |
 | <a name="input_ip_address"></a> [ip\_address](#input\_ip\_address) | Private IP address of the virtual machine NIC. | `string` | `null` | no |
 | <a name="input_ip_forwarding"></a> [ip\_forwarding](#input\_ip\_forwarding) | Enable IP forwarding on the virtual machine NIC. | `bool` | `false` | no |
-| <a name="input_lb_backend_address_pool_ids"></a> [lb\_backend\_address\_pool\_ids](#input\_lb\_backend\_address\_pool\_ids) | IDs of load balancer backends to assign this virtual machine's primary NIC to. | `set(string)` | `[]` | no |
+| <a name="input_lb_backend_address_pool_ids"></a> [lb\_backend\_address\_pool\_ids](#input\_lb\_backend\_address\_pool\_ids) | IDs of load balancer backends to assign this virtual machine's primary NIC to. | `list(string)` | `[]` | no |
 | <a name="input_license_type"></a> [license\_type](#input\_license\_type) | License type to use when building the virtual machine. | `string` | `null` | no |
 | <a name="input_location"></a> [location](#input\_location) | The location of created resources. | `string` | `"uksouth"` | no |
 | <a name="input_network_security_group_enabled"></a> [network\_security\_group\_enabled](#input\_network\_security\_group\_enabled) | Assign a network security group. | `bool` | `false` | no |

--- a/azure/windows-virtual-machine/README.md
+++ b/azure/windows-virtual-machine/README.md
@@ -35,6 +35,7 @@ When using a marketplace image, ensure that you accept the terms using the cli t
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group this module will use. | `string` | n/a | yes |
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | Subnet ID of the virtual machine. | `string` | n/a | yes |
 | <a name="input_accept_terms"></a> [accept\_terms](#input\_accept\_terms) | Enable if terms are needed to be accepted | `bool` | `false` | no |
+| <a name="input_agw_backend_address_pool_ids"></a> [agw\_backend\_address\_pool\_ids](#input\_agw\_backend\_address\_pool\_ids) | IDs of application gateways backends to assign this virtual machine's primary NIC to. | `set(string)` | `[]` | no |
 | <a name="input_autoshutdown"></a> [autoshutdown](#input\_autoshutdown) | Describes the autoshutdown configuration with time being in 24h format and timezone being a supported timezone. | <pre>object({<br>    time     = optional(string, "2200")<br>    timezone = optional(string, "UTC")<br>    email    = optional(string)<br>  })</pre> | `null` | no |
 | <a name="input_availability_set_id"></a> [availability\_set\_id](#input\_availability\_set\_id) | Availability set ID to add this virtual machine to. | `string` | `null` | no |
 | <a name="input_computer_name"></a> [computer\_name](#input\_computer\_name) | The OS-level computer name of the virtual machine. | `string` | `null` | no |
@@ -48,6 +49,7 @@ When using a marketplace image, ensure that you accept the terms using the cli t
 | <a name="input_identity_ids"></a> [identity\_ids](#input\_identity\_ids) | User assigned identity IDs to append to this virtual machine. | `list(string)` | `[]` | no |
 | <a name="input_ip_address"></a> [ip\_address](#input\_ip\_address) | Private IP address of the virtual machine NIC. | `string` | `null` | no |
 | <a name="input_ip_forwarding"></a> [ip\_forwarding](#input\_ip\_forwarding) | Enable IP forwarding on the virtual machine NIC. | `bool` | `false` | no |
+| <a name="input_lb_backend_address_pool_ids"></a> [lb\_backend\_address\_pool\_ids](#input\_lb\_backend\_address\_pool\_ids) | IDs of load balancer backends to assign this virtual machine's primary NIC to. | `set(string)` | `[]` | no |
 | <a name="input_license_type"></a> [license\_type](#input\_license\_type) | License type to use when building the virtual machine. | `string` | `null` | no |
 | <a name="input_location"></a> [location](#input\_location) | The location of created resources. | `string` | `"uksouth"` | no |
 | <a name="input_network_security_group_enabled"></a> [network\_security\_group\_enabled](#input\_network\_security\_group\_enabled) | Assign a network security group. | `bool` | `false` | no |
@@ -86,6 +88,8 @@ When using a marketplace image, ensure that you accept the terms using the cli t
 | [azurerm_marketplace_agreement.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/marketplace_agreement) | resource |
 | [azurerm_monitor_data_collection_rule_association.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_data_collection_rule_association) | resource |
 | [azurerm_network_interface.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface) | resource |
+| [azurerm_network_interface_application_gateway_backend_address_pool_association.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface_application_gateway_backend_address_pool_association) | resource |
+| [azurerm_network_interface_backend_address_pool_association.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface_backend_address_pool_association) | resource |
 | [azurerm_network_interface_security_group_association.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface_security_group_association) | resource |
 | [azurerm_public_ip.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |
 | [azurerm_virtual_machine_extension.main_aadlogin](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_machine_extension) | resource |

--- a/azure/windows-virtual-machine/main.tf
+++ b/azure/windows-virtual-machine/main.tf
@@ -27,6 +27,22 @@ resource "azurerm_network_interface" "main" {
   }
 }
 
+resource "azurerm_network_interface_backend_address_pool_association" "main" {
+  for_each = var.lb_backend_address_pool_ids
+
+  ip_configuration_name   = one(azurerm_network_interface.main.ip_configuration[*].name)
+  network_interface_id    = azurerm_network_interface.main.id
+  backend_address_pool_id = each.value
+}
+
+resource "azurerm_network_interface_application_gateway_backend_address_pool_association" "main" {
+  for_each = var.agw_backend_address_pool_ids
+
+  ip_configuration_name   = one(azurerm_network_interface.main.ip_configuration[*].name)
+  network_interface_id    = azurerm_network_interface.main.id
+  backend_address_pool_id = each.value
+}
+
 resource "azurerm_network_interface_security_group_association" "main" {
   count = var.network_security_group_enabled ? 1 : 0
 

--- a/azure/windows-virtual-machine/main.tf
+++ b/azure/windows-virtual-machine/main.tf
@@ -28,19 +28,19 @@ resource "azurerm_network_interface" "main" {
 }
 
 resource "azurerm_network_interface_backend_address_pool_association" "main" {
-  for_each = var.lb_backend_address_pool_ids
+  count = length(var.lb_backend_address_pool_ids)
 
   ip_configuration_name   = one(azurerm_network_interface.main.ip_configuration[*].name)
   network_interface_id    = azurerm_network_interface.main.id
-  backend_address_pool_id = each.value
+  backend_address_pool_id = var.lb_backend_address_pool_ids[count.index]
 }
 
 resource "azurerm_network_interface_application_gateway_backend_address_pool_association" "main" {
-  for_each = var.agw_backend_address_pool_ids
+  count = length(var.agw_backend_address_pool_ids)
 
   ip_configuration_name   = one(azurerm_network_interface.main.ip_configuration[*].name)
   network_interface_id    = azurerm_network_interface.main.id
-  backend_address_pool_id = each.value
+  backend_address_pool_id = var.agw_backend_address_pool_ids[count.index]
 }
 
 resource "azurerm_network_interface_security_group_association" "main" {

--- a/azure/windows-virtual-machine/variables.tf
+++ b/azure/windows-virtual-machine/variables.tf
@@ -77,13 +77,13 @@ variable "public_ip_enabled" {
 
 variable "lb_backend_address_pool_ids" {
   description = "IDs of load balancer backends to assign this virtual machine's primary NIC to."
-  type        = set(string)
+  type        = list(string)
   default     = []
 }
 
 variable "agw_backend_address_pool_ids" {
   description = "IDs of application gateways backends to assign this virtual machine's primary NIC to."
-  type        = set(string)
+  type        = list(string)
   default     = []
 }
 

--- a/azure/windows-virtual-machine/variables.tf
+++ b/azure/windows-virtual-machine/variables.tf
@@ -75,6 +75,18 @@ variable "public_ip_enabled" {
   default     = false
 }
 
+variable "lb_backend_address_pool_ids" {
+  description = "IDs of load balancer backends to assign this virtual machine's primary NIC to."
+  type        = set(string)
+  default     = []
+}
+
+variable "agw_backend_address_pool_ids" {
+  description = "IDs of application gateways backends to assign this virtual machine's primary NIC to."
+  type        = set(string)
+  default     = []
+}
+
 variable "network_security_group_enabled" {
   description = "Assign a network security group."
   type        = bool


### PR DESCRIPTION
# Description

Add LB and AGW backend address pool associations to VM modules to support in-module handling of address pools.

## Type of change

Please delete options that are not relevant.

  - [x] New feature (non-breaking change which adds functionality)

# Checklist:

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings e.g. code analysis tooling or general use of the changed code
