### PR TITLE
no default probe port should be set by us

### DIFF
--- a/azure/application-gateway/advanced/variables.tf
+++ b/azure/application-gateway/advanced/variables.tf
@@ -269,7 +269,7 @@ variable "probe" {
     path                                      = optional(string, "/")
     timeout                                   = optional(number, 30)
     unhealthy_threshold                       = optional(number, 3)
-    port                                      = optional(number, 80)
+    port                                      = optional(number)
     pick_host_name_from_backend_http_settings = optional(bool, false)
     host                                      = optional(string)
     match = optional(list(object({


### PR DESCRIPTION
# Description

Default port for AppGW shouldn't be set by us. 

Reason for this is by default a null value on the probe will tell AppGW to use backend http settings, by overriding this value on our module we are removing this default on the provider

## Type of change

Please delete options that are not relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my code
  - [X] I have commented my code, particularly in hard-to-understand areas
  - [X] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings e.g. code analysis tooling or general use of the changed code
