### PR TITLE
Fixed condition where host_names is empty list

### DIFF
--- a/azure/application-gateway/advanced/main.tf
+++ b/azure/application-gateway/advanced/main.tf
@@ -178,11 +178,11 @@ resource "azurerm_application_gateway" "main" {
       require_sni                    = http_listener.value["https_enabled"]
       host_name = alltrue([
         length(http_listener.value["host_names"]) == 1,                                                  // Check to make sure there is only 1 hostname in the list
-        length(regexall("^(\\*\\.){1}([\\w-]+\\.)+[\\w-]+$", http_listener.value["host_names"][0])) == 0 // Check to make sure our host is not a wildcard
+        length(regexall("^(\\*\\.){1}([\\w-]+\\.)+[\\w-]+$", try(http_listener.value["host_names"][0],""))) == 0 // Check to make sure our host is not a wildcard
       ]) ? http_listener.value["host_names"][0] : null
       host_names = anytrue([
         length(http_listener.value["host_names"]) > 1,                                                  // Check if there is more than 1 hostname in the list
-        length(regexall("^(\\*\\.){1}([\\w-]+\\.)+[\\w-]+$", http_listener.value["host_names"][0])) > 0 // OR check if the single hostname is a wildcard
+        length(regexall("^(\\*\\.){1}([\\w-]+\\.)+[\\w-]+$", try(http_listener.value["host_names"][0],""))) > 0 // OR check if the single hostname is a wildcard
       ]) ? http_listener.value["host_names"] : null
       ssl_certificate_name = http_listener.value["ssl_certificate_name"]
     }


### PR DESCRIPTION
# Description

- Setting listener host_names to empty list (which is default) caused a terraform error. This has been fixed with a try() function

I had considered using the one() function to fix this but the regexall() function only accepts string inputs so null did not work either. 

## Type of change

  - [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my code
  - [X] I have commented my code, particularly in hard-to-understand areas
  - [X] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings e.g. code analysis tooling or general use of the changed code
