### PR TITLE
adding option to create bastion resource group

### DIFF
--- a/azure/hub/README.md
+++ b/azure/hub/README.md
@@ -15,6 +15,8 @@ This module deploys a predefined hub network with the option to include focused 
 
 This module creates a single resource group for all hub related resources.  
 
+If a resource group name for Bastion is specified, a resource group will be created.  If no name is entered, the main hub resource group will be used.
+
 ### Network Watcher
 In order to manage network watcher via Terraform, the automatic creation of Network Watcher in Azure needs to be disabled in the subscription. Otherwise Terraform will error out.
 
@@ -41,7 +43,7 @@ az provider register -n Microsoft.Network
 | <a name="input_location"></a> [location](#input\_location) | Location to deploy to. | `string` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Name of the resource group created for the hub. | `string` | n/a | yes |
 | <a name="input_virtual_network_name"></a> [virtual\_network\_name](#input\_virtual\_network\_name) | Name of the virtual network. | `string` | n/a | yes |
-| <a name="input_bastion_config"></a> [bastion\_config](#input\_bastion\_config) | Configuration for the bastion if enabled. | <pre>object({<br>    name                        = string<br>    subnet_prefix               = string<br>    public_ip_name              = optional(string)<br>    network_security_group_name = optional(string)<br>    whitelist_cidrs             = optional(list(string), ["Internet"])<br>  })</pre> | `null` | no |
+| <a name="input_bastion_config"></a> [bastion\_config](#input\_bastion\_config) | Configuration for the bastion if enabled. | <pre>object({<br>    name                        = string<br>    resource_group_name         = optional(string)<br>    subnet_prefix               = string<br>    public_ip_name              = optional(string)<br>    network_security_group_name = optional(string)<br>    whitelist_cidrs             = optional(list(string), ["Internet"])<br>  })</pre> | `null` | no |
 | <a name="input_extra_subnets"></a> [extra\_subnets](#input\_extra\_subnets) | Miscelaneous additional subnets to add. | <pre>map(object({<br>    prefix                                        = string<br>    service_endpoints                             = optional(list(string))<br>    private_endpoint_network_policies_enabled     = optional(bool)<br>    private_link_service_network_policies_enabled = optional(bool)<br>    delegations = optional(map(<br>      object({<br>        service = string<br>        actions = list(string)<br>      })<br>    ), {})<br>  }))</pre> | `{}` | no |
 | <a name="input_firewall_config"></a> [firewall\_config](#input\_firewall\_config) | Configuration for the firewall if enabled. | <pre>object({<br>    name               = string<br>    subnet_prefix      = string<br>    public_ip_name     = optional(string)<br>    sku_tier           = optional(string, "Standard")<br>    route_table_name   = optional(string)<br>    firewall_policy_id = optional(string)<br>  })</pre> | `null` | no |
 | <a name="input_log_analytics_workspace_id"></a> [log\_analytics\_workspace\_id](#input\_log\_analytics\_workspace\_id) | Log analytics workspace ID to forward diagnostics to. | `string` | `null` | no |
@@ -80,6 +82,7 @@ az provider register -n Microsoft.Network
 | [azurerm_private_dns_resolver_outbound_endpoint.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_resolver_outbound_endpoint) | resource |
 | [azurerm_private_dns_zone.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
 | [azurerm_public_ip.virtual_network_gateway](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |
+| [azurerm_resource_group.bastion](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.network_watcher](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_route.firewall](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/route) | resource |

--- a/azure/hub/bastion.tf
+++ b/azure/hub/bastion.tf
@@ -3,7 +3,7 @@
 #################
 
 resource "azurerm_resource_group" "bastion" {
-  count = local.bastion_create_resource_group ? 1 : 0
+  count = var.bastion_config.resource_group_name != null ? 1 : 0
 
   name     = var.bastion_config.resource_group_name
   location = var.location

--- a/azure/hub/bastion.tf
+++ b/azure/hub/bastion.tf
@@ -1,3 +1,15 @@
+#################
+# Resource Group
+#################
+
+resource "azurerm_resource_group" "bastion" {
+  count = local.bastion_create_resource_group ? 1 : 0
+
+  name     = var.bastion_config.resource_group_name
+  location = var.location
+  tags     = var.tags
+}
+
 ##########
 # Bastion
 ##########
@@ -8,7 +20,7 @@ module "bastion" {
 
   name                = var.bastion_config["name"]
   location            = var.location
-  resource_group_name = azurerm_resource_group.main.name
+  resource_group_name = local.bastion_resource_group_name
   tags                = var.tags
 
   subnet_id                   = local.bastion_subnet.id

--- a/azure/hub/examples/advanced/main.tf
+++ b/azure/hub/examples/advanced/main.tf
@@ -1,5 +1,9 @@
 provider "azurerm" {
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 }
 
 locals {

--- a/azure/hub/examples/advanced/main.tf
+++ b/azure/hub/examples/advanced/main.tf
@@ -72,7 +72,7 @@ module "hub" {
 module "firewall-policy" {
   source = "../../../firewall-policy"
 
-  name                     = "fwpol-${local.resource_prefix}"
+  name                     = "fwpol-hub-${local.resource_prefix}"
   resource_group_name      = module.hub.resource_group_name
   location                 = local.location
   tags                     = local.tags

--- a/azure/hub/examples/advanced/main.tf
+++ b/azure/hub/examples/advanced/main.tf
@@ -43,7 +43,8 @@ module "hub" {
   }
 
   bastion_config = {
-    name          = "bas-hub-${local.resource_prefix}"
+    name = "bas-hub-${local.resource_prefix}"
+    resource_group_name = "rg-bas-${local.resource_prefix}"
     subnet_prefix = "10.0.15.0/26"
   }
 
@@ -76,7 +77,7 @@ module "firewall-policy" {
 
   rule_collection_groups = {
     ApplicationOne = {
-      priority             = "100"
+      priority = "100"
     }
   }
 }

--- a/azure/hub/examples/advanced/main.tf
+++ b/azure/hub/examples/advanced/main.tf
@@ -47,9 +47,9 @@ module "hub" {
   }
 
   bastion_config = {
-    name = "bas-hub-${local.resource_prefix}"
+    name                = "bas-hub-${local.resource_prefix}"
     resource_group_name = "rg-bas-${local.resource_prefix}"
-    subnet_prefix = "10.0.15.0/26"
+    subnet_prefix       = "10.0.15.0/26"
   }
 
   virtual_network_gateway_config = {

--- a/azure/hub/locals.tf
+++ b/azure/hub/locals.tf
@@ -9,11 +9,10 @@ locals {
   firewall             = one(module.firewall)
   firewall_route_table = one(azurerm_route_table.firewall)
 
-  enable_bastion                = var.bastion_config != null
-  bastion                       = one(module.bastion)
-  bastion_create_resource_group = var.bastion_config.resource_group_name != null
-  bastion_resource_group_name   = var.bastion_config.resource_group_name != null ? var.bastion_config.resource_group_name : azurerm_resource_group.main.name
-  bastion_subnet                = local.enable_bastion ? module.network.subnets["AzureBastionSubnet"] : null
+  enable_bastion              = var.bastion_config != null
+  bastion                     = one(module.bastion)
+  bastion_resource_group_name = var.bastion_config.resource_group_name != null ? var.bastion_config.resource_group_name : azurerm_resource_group.main.name
+  bastion_subnet              = local.enable_bastion ? module.network.subnets["AzureBastionSubnet"] : null
 
   enable_virtual_network_gateway = var.virtual_network_gateway_config != null
   virtual_network_gateway        = one(azurerm_virtual_network_gateway.main)

--- a/azure/hub/locals.tf
+++ b/azure/hub/locals.tf
@@ -9,9 +9,11 @@ locals {
   firewall             = one(module.firewall)
   firewall_route_table = one(azurerm_route_table.firewall)
 
-  enable_bastion = var.bastion_config != null
-  bastion        = one(module.bastion)
-  bastion_subnet = local.enable_bastion ? module.network.subnets["AzureBastionSubnet"] : null
+  enable_bastion                = var.bastion_config != null
+  bastion                       = one(module.bastion)
+  bastion_create_resource_group = var.bastion_config.resource_group_name != null
+  bastion_resource_group_name   = var.bastion_config.resource_group_name != null ? var.bastion_config.resource_group_name : azurerm_resource_group.main.name
+  bastion_subnet                = local.enable_bastion ? module.network.subnets["AzureBastionSubnet"] : null
 
   enable_virtual_network_gateway = var.virtual_network_gateway_config != null
   virtual_network_gateway        = one(azurerm_virtual_network_gateway.main)

--- a/azure/hub/variables.tf
+++ b/azure/hub/variables.tf
@@ -104,7 +104,7 @@ variable "firewall_config" {
 
   validation {
     error_message = "Must be valid IPv4 CIDR."
-    condition     = var.firewall_config == null || can(cidrhost(var.firewall_config.subnet_prefix, 0)
+    condition = var.firewall_config == null || can(cidrhost(var.firewall_config.subnet_prefix, 0)
     )
   }
   validation {
@@ -121,6 +121,7 @@ variable "bastion_config" {
   description = "Configuration for the bastion if enabled."
   type = object({
     name                        = string
+    resource_group_name         = optional(string)
     subnet_prefix               = string
     public_ip_name              = optional(string)
     network_security_group_name = optional(string)
@@ -169,7 +170,7 @@ variable "virtual_network_gateway_config" {
 
   validation {
     error_message = "If the sku is set to Basic, VpnGw1 or VpnGw1AZ, then generation must be set to Generation1."
-    condition     = contains(["Basic", "VpnGw1", "VpnGw1AZ"], try(var.virtual_network_gateway_config.sku,[])) ? var.virtual_network_gateway_config.generation == "Generation1" : true
+    condition     = contains(["Basic", "VpnGw1", "VpnGw1AZ"], try(var.virtual_network_gateway_config.sku, [])) ? var.virtual_network_gateway_config.generation == "Generation1" : true
   }
 
   validation {


### PR DESCRIPTION
# Description

Adding the option to create a resource group for Bastion.  If the resource group name is left empty, the main hub resource group is used. 

## Type of change

Please select the option that is relevant.

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [x] This change requires a documentation update

# Checklist:

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings e.g. code analysis tooling or general use of the changed code