### PR TITLE
Switched to versionless SSL certificate

### DIFF
--- a/azure/application-gateway/advanced/main.tf
+++ b/azure/application-gateway/advanced/main.tf
@@ -243,7 +243,7 @@ resource "azurerm_application_gateway" "main" {
         ssl_certificate.value["key_vault_secret_id"] == null,
         ssl_certificate.value["data"] == null,
         ssl_certificate.value["password"] == null
-      ]) ? azurerm_key_vault_certificate.main[ssl_certificate.key].secret_id : ssl_certificate.value["key_vault_secret_id"]
+      ]) ? azurerm_key_vault_certificate.main[ssl_certificate.key].versionless_secret_id : ssl_certificate.value["key_vault_secret_id"]
     }
   }
 


### PR DESCRIPTION
# Description

The application gateway should default to a versionless variant of the keyvault cert so that the end user can modify the keyvault cert without needing to update the appgw

## Type of change

Please select the option that is relevant.

  - [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

  - [X] My code follows the style guidelines of this project
  - [X] I have performed a self-review of my code
  - [X] I have commented my code, particularly in hard-to-understand areas
  - [X] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings e.g. code analysis tooling or general use of the changed code
