### PR TITLE
Changing spoke vnet peering name to reflect Terraform standards

### DIFF
--- a/azure/spoke/main.tf
+++ b/azure/spoke/main.tf
@@ -99,7 +99,7 @@ resource "azurerm_network_watcher" "main" {
 resource "azurerm_virtual_network_peering" "main" {
   for_each = var.vnet_peering
 
-  name                      = format("%s_to_%s", module.network.name, each.key)
+  name                      = format("%s-to-%s", module.network.name, each.key)
   virtual_network_name      = module.network.name
   resource_group_name       = module.network.resource_group_name
   remote_virtual_network_id = each.value["remote_vnet_id"]


### PR DESCRIPTION
# Description

Change to naming of spoke module peering.

From \_to\_
To -to-

## Type of change

Please select the option that is relevant.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update

# Checklist:

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings e.g. code analysis tooling or general use of the changed code
